### PR TITLE
Optional command line arguments to 'fips run'

### DIFF
--- a/mod/project.py
+++ b/mod/project.py
@@ -268,7 +268,7 @@ def run(fips_dir, proj_dir, cfg_name, target_name, target_args) :
                     log.error("don't know how to start HTML app on this platform")
             elif os.path.isdir('{}/{}.app'.format(deploy_dir, target_name)) :
                 # special case: Mac app
-                cmd_line = ['open', '{}/{}.app'.format(deploy_dir, target_name, target_args)]
+                cmd_line = ['open', '{}/{}.app'.format(deploy_dir, target_name)]
                 if target_args :
                     cmd_line.append('--args')
             else :

--- a/mod/project.py
+++ b/mod/project.py
@@ -215,14 +215,14 @@ def build(fips_dir, proj_dir, cfg_name, target=None) :
         return True
 
 #-------------------------------------------------------------------------------
-def run(fips_dir, proj_dir, cfg_name, target_name) :
+def run(fips_dir, proj_dir, cfg_name, target_name, target_args) :
     """run a build target executable
 
     :param fips_dir:    absolute path of fips
     :param proj_dir:    absolute path of project dir
     :param cfg_name:    config name or pattern
     :param target_name: the target name
-    :returns:           True if build was successful
+    :param target_args: command line arguments for build target
     """
 
     proj_name = util.get_project_name_from_dir(proj_dir)
@@ -268,10 +268,14 @@ def run(fips_dir, proj_dir, cfg_name, target_name) :
                     log.error("don't know how to start HTML app on this platform")
             elif os.path.isdir('{}/{}.app'.format(deploy_dir, target_name)) :
                 # special case: Mac app
-                cmd_line = ['open', '{}/{}.app'.format(deploy_dir, target_name)]
+                cmd_line = ['open', '{}/{}.app'.format(deploy_dir, target_name, target_args)]
+                if target_args :
+                    cmd_line.append('--args')
             else :
                 cmd_line = [ '{}/{}'.format(deploy_dir, target_name) ]
             if cmd_line :
+                if target_args :
+                    cmd_line.extend(target_args)
                 try:
                     subprocess.call(args=cmd_line, cwd=deploy_dir)
                 except OSError, e:

--- a/verbs/run.py
+++ b/verbs/run.py
@@ -13,12 +13,17 @@ def run(fips_dir, proj_dir, args) :
         log.error('must be run in a project directory')
     cfg_name = settings.get(proj_dir, 'config')
     target_name = settings.get(proj_dir, 'target')
+    target_args = []
+    if '--' in args :
+        idx = args.index('--')
+        target_args = args[(idx + 1):]
+        args = args[:idx]
     if len(args) > 0 :
         target_name = args[0]
-    if len(args) > 1:
+    if len(args) > 1 :
         cfg_name = args[1]
     if target_name :
-        project.run(fips_dir, proj_dir, cfg_name, target_name)
+        project.run(fips_dir, proj_dir, cfg_name, target_name, target_args)
     else :
         log.error('no target provided')
 


### PR DESCRIPTION
OS X / Linux / Windows: pass command line arguments to target with:

```
./fips run [target] [config] -- <list of arguments>
```