### PR TITLE
Add fips-recast to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ there may be fipsified projects that are not in the registry):
 - **fips-sauce**:           https://github.com/mgerhardy/fips-sauce
 - **fips-googletest**:      https://github.com/mgerhardy/fips-googletest
 - **fips-freetype2**:       https://github.com/mgerhardy/fips-freetype2
+- **fips-recast**:          https://github.com/fungos/fips-recast.git
 
 Test projects:
 

--- a/registry.yml
+++ b/registry.yml
@@ -25,3 +25,4 @@ fips-remotery:      https://github.com/floooh/fips-remotery.git
 fips-accidentalnoise: https://github.com/mgerhardy/fips-accidentalnoise.git
 fips-googletest:    https://github.com/mgerhardy/fips-googletest
 fips-freetype2:     https://github.com/mgerhardy/fips-freetype2
+fips-recast:        https://github.com/fungos/fips-recast.git


### PR DESCRIPTION
Add recast to registry. 
I've converted recast demo to glfw3 as I'd said it would be easier than get a fipsified SDL, but at the same time I've not tested on MacOS (I do not have one) or Windows (but will do soon).

Note: The glfw3 conversion is currently hosted at my fork, but the changes may get accepted upstream as the maintainer already confirmed it prefers glfw. I must only verify that premake4 builds correctly on MacOS and Windows before doing the PR there.
