### PR TITLE
Proposal for #48

### DIFF
--- a/cmake/fips.cmake
+++ b/cmake/fips.cmake
@@ -166,6 +166,9 @@ macro(fips_setup)
     # write empty target files (will be populated in the fips_end macros)
     fips_reset_targets_list()
 
+    # initialize code generation
+    fips_begin_gen()
+
     # load project-local fips-include.cmake if exists
     if (EXISTS "${FIPS_PROJECT_DIR}/fips-include.cmake")
         include("${FIPS_PROJECT_DIR}/fips-include.cmake")
@@ -212,7 +215,6 @@ macro(fips_begin_module name)
     if (FIPS_CMAKE_VERBOSE)
         message("Module: name=" ${name})
     endif()
-    fips_begin_gen(${name})
     fips_reset(${name})
 endmacro()
 
@@ -261,7 +263,6 @@ macro(fips_begin_lib name)
     if (FIPS_CMAKE_VERBOSE)
         message("Library: name=" ${name})
     endif()
-    fips_begin_gen(${name})
     fips_reset(${name})
 endmacro()
 
@@ -308,7 +309,6 @@ endmacro()
 #
 macro(fips_begin_app name type)
     if (${type} STREQUAL "windowed" OR ${type} STREQUAL "cmdline")
-        fips_begin_gen(${name})
         fips_reset(${name})
         set(CurAppType ${type})
         if (FIPS_CMAKE_VERBOSE)
@@ -408,7 +408,6 @@ endmacro()
 #   Begin a fips shared library.
 #
 macro(fips_begin_sharedlib name)
-    fips_begin_gen(${name})
     fips_reset(${name})
     if (FIPS_CMAKE_VERBOSE)
         message("Shared Lib: name=" ${CurTargetName})

--- a/cmake/fips_generators.cmake
+++ b/cmake/fips_generators.cmake
@@ -37,9 +37,9 @@
 #   Called from fips_begin_module, fips_begin_lib, fips_begin_app to 
 #   clear the generator .yml file.
 #
-macro(fips_begin_gen target)
-    file(REMOVE "${CMAKE_BINARY_DIR}/fips_codegen_${target}.yml")
-    set(CurProjectHasCodeGen${target})
+macro(fips_begin_gen)
+    file(REMOVE "${CMAKE_BINARY_DIR}/fips_codegen.yml")
+    set(CurProjectHasCodeGen)
 endmacro()
 
 #-------------------------------------------------------------------------------
@@ -83,8 +83,8 @@ macro(fips_add_generator target in_generator in_file out_src out_hdr args)
         if (NOT ${args} STREQUAL "")
             set(yml_content "${yml_content}  args: ${args}\n")
         endif()
-        file(APPEND "${CMAKE_BINARY_DIR}/fips_codegen_${target}.yml" "${yml_content}")
-        set(CurProjectHasCodeGen${target} 1)
+        file(APPEND "${CMAKE_BINARY_DIR}/fips_codegen.yml" "${yml_content}")
+        set(CurProjectHasCodeGen 1)
     endif()
 endmacro()
             
@@ -92,21 +92,6 @@ endmacro()
 #   fips_handle_py_files_posttarget(target pyFiles)
 #   Create custom target for .py generator files.
 #
-macro(fips_handle_generators target) 
-    if (CurProjectHasCodeGen${target})
-        if (NOT TARGET GENERATE_FOR_${target})
-            add_custom_target(GENERATE_FOR_${target}
-                COMMAND ${PYTHON} ${FIPS_PROJECT_DIR}/.fips-gen.py ${CMAKE_BINARY_DIR}/fips_codegen_${target}.yml
-                WORKING_DIRECTORY ${FIPS_PROJECT_DIR})
-
-            if (CurTargetDependencies)
-                add_dependencies(GENERATE_FOR_${target} ${CurTargetDependencies})
-            endif()
-        endif()
-        add_dependencies(${target} GENERATE_FOR_${target})
-    endif()
-endmacro()
-
 macro(fips_handle_generators target) 
     if (CurProjectHasCodeGen)
         if (NOT TARGET ALL_GENERATE)

--- a/cmake/fips_generators.cmake
+++ b/cmake/fips_generators.cmake
@@ -107,3 +107,17 @@ macro(fips_handle_generators target)
     endif()
 endmacro()
 
+macro(fips_handle_generators target) 
+    if (CurProjectHasCodeGen)
+        if (NOT TARGET ALL_GENERATE)
+            add_custom_target(ALL_GENERATE
+                COMMAND ${PYTHON} ${FIPS_PROJECT_DIR}/.fips-gen.py ${CMAKE_BINARY_DIR}/fips_codegen.yml
+                WORKING_DIRECTORY ${FIPS_PROJECT_DIR})
+
+             if (CurTargetDependencies)
+                add_dependencies(ALL_GENERATE ${CurTargetDependencies})
+            endif()               
+        endif()
+        add_dependencies(${target} ALL_GENERATE)
+    endif()
+endmacro()

--- a/cmake/fips_generators.cmake
+++ b/cmake/fips_generators.cmake
@@ -99,8 +99,8 @@ macro(fips_handle_generators target)
                 COMMAND ${PYTHON} ${FIPS_PROJECT_DIR}/.fips-gen.py ${CMAKE_BINARY_DIR}/fips_codegen_${target}.yml
                 WORKING_DIRECTORY ${FIPS_PROJECT_DIR})
 
-            if (CurRequirements)
-                add_dependencies(GENERATE_FOR_${target} ${CurRequirements})
+            if (CurTargetDependencies)
+                add_dependencies(GENERATE_FOR_${target} ${CurTargetDependencies})
             endif()
         endif()
         add_dependencies(${target} GENERATE_FOR_${target})

--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -234,4 +234,21 @@ macro(fips_add_file new_file)
     endif()
 endmacro()
 
+#-------------------------------------------------------------------------------
+#   fips_add_target_dependency(target...)
+#   Add one or more dependencies to the current target. The dependencies
+#   must be cmake build targets defined with fips_begin*/fips_end*().
+#   Used to define a build order required when, for exemple, building tools to
+#   use during compilation of the current target.
+#
+macro(fips_add_target_dependency targets)
+    foreach(target ${ARGV})
+        if (TARGET ${target})
+            list(APPEND CurTargetDependencies ${target})
+        endif()
+    endforeach()
 
+    if (CurTargetDependencies)
+        list(REMOVE_DUPLICATES CurTargetDependencies)
+    endif()
+endmacro()

--- a/mod/dep.py
+++ b/mod/dep.py
@@ -279,7 +279,7 @@ def write_imports(fips_dir, proj_dir, imported) :
     :params proj_dir:   absolute path to current project
     :params imported:   the imports dictionary created with 'gather_imports'
     """
-    
+
     if imported :
         unique_hdrdirs = []
         unique_libdirs = []
@@ -351,15 +351,15 @@ def write_imports(fips_dir, proj_dir, imported) :
         else :
             os.remove(import_tmp_filename)
 
-        # write the .fips-imports.py file (copy from template)
-        gen_search_paths  = '"{}","{}/generators",\n'.format(fips_dir, fips_dir)
-        if os.path.isdir("{}/fips-generators".format(proj_dir)) :
-            gen_search_paths += '"{}","{}/fips-generators",\n'.format(proj_dir, proj_dir)
-        for imp_proj_name in imported :
-            gen_dir = util.get_project_dir(fips_dir, imp_proj_name) + '/fips-generators'
-            if os.path.isdir(gen_dir) :
-                gen_search_paths += '"' + gen_dir + '",\n' 
-        template.copy_template_file(fips_dir, proj_dir, '.fips-gen.py', { 'genpaths': gen_search_paths}, True)
+    # write the .fips-imports.py file (copy from template)
+    gen_search_paths  = '"{}","{}/generators",\n'.format(fips_dir, fips_dir)
+    if os.path.isdir("{}/fips-generators".format(proj_dir)) :
+        gen_search_paths += '"{}","{}/fips-generators",\n'.format(proj_dir, proj_dir)
+    for imp_proj_name in imported :
+        gen_dir = util.get_project_dir(fips_dir, imp_proj_name) + '/fips-generators'
+        if os.path.isdir(gen_dir) :
+            gen_search_paths += '"' + gen_dir + '",\n' 
+    template.copy_template_file(fips_dir, proj_dir, '.fips-gen.py', { 'genpaths': gen_search_paths}, True)
 
 #-------------------------------------------------------------------------------
 def gather_and_write_imports(fips_dir, proj_dir) :


### PR DESCRIPTION
Implements a proposal for issue #48 (and floooh/fips-bgfx#4):
- adds a fips_requires(target ...) that only creates a dependency link between current target from fips_begin/end_*() to the targets required. This can be used to force tools compilation before the current target build.
- changes fips_generate and fips_handle_generators to use required targets.
- changes generation build target from ALL_GENERATE to generate only for the targets that uses a fips_generate. Otherwise generators will happens only before anything else, but we want specify order via requires.

Bonus:
- fix .fips-gen.py generation when the project does not import anything.
- fix some trailing spaces (side-effect from my editing, sorry).