### PR TITLE
Linux: added option to compile 32-bit builds on 64-bit hosts

### DIFF
--- a/cmake-toolchains/linux.cmake
+++ b/cmake-toolchains/linux.cmake
@@ -33,18 +33,25 @@ else()
     set(FIPS_LINUX_RTTI_FLAGS "-fno-rtti")
 endif()
 
+# 32-bit build on/off?
+if (FIPS_LINUX_MACH32)
+    set(FIPS_LINUX_MACH_FLAGS "-m32")
+else()
+    set(FIPS_LINUX_MACH_FLAGS "")
+endif()
+
 # C++ flags
-set(CMAKE_CXX_FLAGS "${FIPS_LINUX_EXCEPTION_FLAGS} ${FIPS_LINUX_RTTI_FLAGS} -std=c++11 -pthread -fno-strict-aliasing -Wno-multichar -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-ignored-qualifiers")
+set(CMAKE_CXX_FLAGS "${FIPS_LINUX_EXCEPTION_FLAGS} ${FIPS_LINUX_RTTI_FLAGS} ${FIPS_LINUX_MACH_FLAGS} -std=c++11 -pthread -fno-strict-aliasing -Wno-multichar -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-ignored-qualifiers")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ftree-vectorize -msse3 -ffast-math -DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -D_DEBUG_ -D_DEBUG -DFIPS_DEBUG=1 -ggdb")
 
 # C flags
-set(CMAKE_C_FLAGS "-pthread -fno-strict-aliasing -Wno-multichar -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-ignored-qualifiers")        
+set(CMAKE_C_FLAGS "${FIPS_LINUX_MACH_FLAGS} -pthread -fno-strict-aliasing -Wno-multichar -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-ignored-qualifiers")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -ftree-vectorize -msse3 -ffast-math -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG "-O0 -D_DEBUG_ -D_DEBUG -DFIPS_DEBUG=1 -ggdb")
 
 # exe linker flags
-set(CMAKE_EXE_LINKER_FLAGS "-pthread -dead_strip -lpthread")
+set(CMAKE_EXE_LINKER_FLAGS "${FIPS_LINUX_MACH_FLAGS} -pthread -dead_strip -lpthread")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "")
 if (FIPS_GCC)

--- a/cmake/fips.cmake
+++ b/cmake/fips.cmake
@@ -35,6 +35,7 @@ option(FIPS_COMPILE_VERBOSE "Enable very verbose compilation" OFF)
 option(FIPS_USE_CCACHE "Enable ccache when building with gcc or clang" OFF)
 option(FIPS_PROFILING "Enable app profiling/tracing" OFF)
 option(FIPS_OSX_UNIVERSAL "Enable generation of universal binaries on OS X" OFF)
+option(FIPS_LINUX_MACH32 "Enable 32-bit code generation on 64-bit Linux host" OFF)
 
 # turn some dependent options on/off
 if (FIPS_UNITTESTS)


### PR DESCRIPTION
Here's another "cross compile" flag. I'm not completely sure there isn't a more convenient option available, but it works.