### PR TITLE
Implements support to specify a revision to use in imports.

### DIFF
--- a/mod/dep.py
+++ b/mod/dep.py
@@ -187,7 +187,12 @@ def _rec_fetch_imports(fips_dir, proj_dir, handled) :
                     git_url = imports[dep_proj_name]['git']
                     git_branch = imports[dep_proj_name]['branch']
                     if git.clone(git_url, git_branch, dep_proj_name, ws_dir) :
-                        dep_ok = True
+                        if 'rev' in imports[dep_proj_name]  :
+                            git_commit = imports[dep_proj_name]['rev']
+                            log.colored(log.YELLOW, "=== revision: '{}':".format(git_commit))
+                            dep_ok = git.checkout(dep_proj_dir, git_commit)
+                        else :
+                            dep_ok = True
                     else :
                         log.error('failed to git clone {} into {}'.format(git_url, dep_proj_dir))
                 else :

--- a/mod/dep.py
+++ b/mod/dep.py
@@ -187,13 +187,8 @@ def _rec_fetch_imports(fips_dir, proj_dir, handled) :
                     git_url = imports[dep_proj_name]['git']
                     git_branch = imports[dep_proj_name]['branch']
                     if git.clone(git_url, git_branch, dep_proj_name, ws_dir) :
-<<<<<<< HEAD
-                        if 'rev' in imports[dep_proj_name]  :
+                        if 'rev' in imports[dep_proj_name] :
                             git_commit = imports[dep_proj_name]['rev']
-=======
-                        git_commit = imports[dep_proj_name]['rev']
-                        if git_commit :
->>>>>>> 1350172d409fc70fdc0c93751223f92f18810d09
                             log.colored(log.YELLOW, "=== revision: '{}':".format(git_commit))
                             dep_ok = git.checkout(dep_proj_dir, git_commit)
                         else :

--- a/mod/tools/git.py
+++ b/mod/tools/git.py
@@ -65,6 +65,21 @@ def get_branches(proj_dir) :
     return branches;
 
 #-------------------------------------------------------------------------------
+def checkout(proj_dir, revision) :
+    """checkout a specific revision hash of a repository
+
+    :param proj_dir:    a git repo dir
+    :param revision:    SHA1 hash of the commit
+    :returns:           True if git returns successful
+    """
+    try :
+        output = subprocess.check_output('git checkout {}'.format(revision), cwd=proj_dir, shell=True)
+        return output.split(':')[0] != 'error'
+    except subprocess.CalledProcessError :
+        log.error("failed to call 'git checkout'")
+        return None
+
+#-------------------------------------------------------------------------------
 def has_uncommitted_files(proj_dir) :
     """check whether a git repo has uncommitted files
 
@@ -115,7 +130,7 @@ def get_local_rev(proj_dir, local_branch) :
     except subprocess.CalledProcessError :
         log.error("failed to call 'git rev-parse'")
         return None
-    
+
 #-------------------------------------------------------------------------------
 def check_out_of_sync(proj_dir) :
     """check through all branches of the git repo in proj_dir and

--- a/site/p060_imports.md
+++ b/site/p060_imports.md
@@ -87,7 +87,7 @@ or Mercurial.
 
 ### Importing specific versions
 
-It is possible to specify a git branch or tag name when defining an import
+It is possible to specify a git branch, tag name or revision when defining an import
 in fips.yml. This is usually a good idea for complex real-world projects 
 since it prevents that a build suddenly breaks because an external dependency
 has had an update that breaks existing code:
@@ -98,12 +98,13 @@ imports:
     my-awesome-lib:
         git: https://github.com/floooh/my-awesome-lib.git
         branch: version-0.0.1
+    my-other-awesome-lib:
+        git: https://github.com/floooh/my-other-awesome-lib.git
+        rev: 00f1a6d3
 {% endhighlight %}
 
 The 'branch:' item can either be a branch or tag name.
-
-> NOTE: it is currently not possible to pin the import version to a random
-git revision that isn't tagged
+The 'rev:' item should be a valid commit SHA1 reference.
 
 ### Fetching imports
 


### PR DESCRIPTION
This will look for an item 'rev:' in fips.yml and if this item exists a
checkout will be made after fetching the imported project.
This way importing projects have more control over imported dependencies
and the risk of breaking when an import changes is reduced.