### PR TITLE
Supports specifying a commit in import directives

### DIFF
--- a/mod/dep.py
+++ b/mod/dep.py
@@ -183,19 +183,19 @@ def _rec_fetch_imports(fips_dir, proj_dir, handled) :
                 log.colored(log.YELLOW, "=== dependency: '{}':".format(dep_proj_name))
                 dep_ok = False
                 if not os.path.isdir(dep_proj_dir) :
-                    # old behaviour if there is no revision and depth parameters
-                    if not 'rev' in imports[dep_proj_name] and not 'depth' in imports[dep_proj_name] :
-                        imports[dep_proj_name]['depth'] = git.clone_depth
                     # directory did not exist, do a fresh git clone
-                    git_url = imports[dep_proj_name]['git']
-                    git_branch = imports[dep_proj_name]['branch']
-                    git_depth = imports[dep_proj_name]['depth']
+                    dep = imports[dep_proj_name]
+                    git_commit = None if 'rev' not in dep else dep['rev']
+                    if git_commit :
+                        if 'depth' in dep :
+                            # when using rev, we may not want depth because the revision may not be reachable
+                            log.colored(log.YELLOW, "=== 'depth' was ignored because parameter 'rev' is specified.")
+                        dep['depth'] = None
+                    git_depth = git.clone_depth if not git_commit and 'depth' not in dep else dep['depth']
+                    git_url = dep['git']
+                    git_branch = dep['branch']
                     if git.clone(git_url, git_branch, git_depth, dep_proj_name, ws_dir) :
-                        if 'rev' in imports[dep_proj_name] :
-                            if 'depth' in imports[dep_proj_name] :
-                                # when using rev, we may not want depth because the revision may not be reachable
-                                log.colored(log.YELLOW, "=== 'depth' was ignored because parameter 'rev' is specified.")
-                            git_commit = imports[dep_proj_name]['rev']
+                        if git_commit :
                             log.colored(log.YELLOW, "=== revision: '{}':".format(git_commit))
                             dep_ok = git.checkout(dep_proj_dir, git_commit)
                         else :

--- a/mod/project.py
+++ b/mod/project.py
@@ -46,7 +46,7 @@ def clone(fips_dir, url) :
     if not os.path.isdir(proj_dir) :
         git_url = util.get_giturl_from_url(url)
         git_branch = util.get_gitbranch_from_url(url)
-        if git.clone(git_url, git_branch, proj_name, ws_dir) :
+        if git.clone(git_url, git_branch, git.clone_depth, proj_name, ws_dir) :
             # fetch imports
             dep.fetch_imports(fips_dir, proj_dir)
             return True

--- a/registry.yml
+++ b/registry.yml
@@ -17,6 +17,7 @@ oryol-test-app:     https://github.com/floooh/oryol-test-app.git
 fips-hello-world:   https://github.com/floooh/fips-hello-world.git
 fips-hello-dep1:    https://github.com/floooh/fips-hello-dep1.git
 fips-hello-dep2:    https://github.com/floooh/fips-hello-dep2.git
+fips-hello-dep3:    https://github.com/floooh/fips-hello-dep3.git
 fips-polyvox:       https://github.com/mgerhardy/fips-polyvox.git
 fips-enet:          https://github.com/mgerhardy/fips-enet.git
 fips-simpleai:      https://github.com/mgerhardy/fips-simpleai.git

--- a/site/p060_imports.md
+++ b/site/p060_imports.md
@@ -87,7 +87,7 @@ or Mercurial.
 
 ### Importing specific versions
 
-It is possible to specify a git branch or tag name when defining an import
+It is possible to specify a git branch, tag name or revision when defining an import
 in fips.yml. This is usually a good idea for complex real-world projects 
 since it prevents that a build suddenly breaks because an external dependency
 has had an update that breaks existing code:
@@ -98,12 +98,13 @@ imports:
     my-awesome-lib:
         git: https://github.com/floooh/my-awesome-lib.git
         branch: version-0.0.1
+    my-other-awesome-lib:
+        git: https://github.com/floooh/my-other-awesome-lib.git
+        rev: 00f1a6d3
 {% endhighlight %}
 
 The 'branch:' item can either be a branch or tag name.
-
-> NOTE: it is currently not possible to pin the import version to a random
-git revision that isn't tagged
+The 'rev:' item should be a valid commit SHA1 reference.
 
 ### Fetching imports
 


### PR DESCRIPTION
This fixes the issues discussed before, if the rev is specified it will not use the depth value. The branch can still be used though. A side effect is that now it is possible to also specify a depth in the import that will override the default of 10 if not specified.

The test for these changes depends on this PR https://github.com/floooh/fips-hello-world/pull/1 and in this new project https://github.com/fungos/fips-hello-dep3