### PR TITLE
Add project fips-tests on travis scripts, this is a reorganized project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,8 @@ script:
     - cd ../fips-hello-dep1
     - python fips gen
     - python fips build
-
-
-
-
-
+    # clone tests project
+    - python fips clone https://github.com/fungos/fips-tests.git
+    - cd ../fips-tests
+    - python fips testrunner linux-make-debug
+    - python fips testrunner linux-make-release

--- a/site/p050_cmakeguide.md
+++ b/site/p050_cmakeguide.md
@@ -203,7 +203,7 @@ fips\_files() must be called inside a module, lib, or app definition block.
 #### fips\_files\_ex(dir glob... \[EXCEPT glob...\] \[GROUP ide\_group\] \[NO\_RECURSE\])
 
 Like fips\_dir(), but will also do a fips\_files() with files found in a directory
-that match an expression fro the glob expression list excluding any file that
+that match an expression from the glob expression list excluding any file that
 is in the `EXCEPT` glob expression list. You can use `NO_RECURSE` so it will not
 search files in subdirectories. 
 


### PR DESCRIPTION
that we can use to add fips feature tests. Any target starting by 'test_'
will be ran automatically with testrunner.py, other targets are ignored.

Also fix a minor typo in the doc.

(fix tests, retry travis-ci)