### PR TITLE
Add support to Cygwin

### DIFF
--- a/mod/util.py
+++ b/mod/util.py
@@ -201,6 +201,9 @@ def get_host_platform() :
 
     :returns: platform name (osx, linux, win)
     """
+    plat = platform.system()
+    if "CYGWIN_NT" in plat:
+        return host_platforms['Linux']
     return host_platforms[platform.system()]
 
 


### PR DESCRIPTION
This matches any Cygwin version to be mapped as a Linux platform.
The cygwin platform identification normally should match the CYGWIN_NT-X
where X is the underlying Windows version. Tested this on Windows 10 with
Cygwin x86_64 and was able to build fips-hello-world project.

Closes #128