### PR TITLE
Update .fips-gen.py

### DIFF
--- a/templates/.fips-gen.py
+++ b/templates/.fips-gen.py
@@ -43,7 +43,7 @@ def processFile(attrs) :
     if args :
         module.generate(input, out_src, out_hdr, args)
     else :
-        module.generate(input, out_src, out_hdr)
+        module.generate(input, out_src, out_hdr, None)
 
 #=== entry point
 if len(sys.argv) == 2 :


### PR DESCRIPTION
When trying to setup a project as explained in https://www.youtube.com/watch?v=fcmOhvVd80o, I got an error when building in VS 2015, telling me "module.generate requires exactly 4 arguments". I added "None" as the fourth argument when args was not resolved.