### PR TITLE
Check file exists before trying to parse version

### DIFF
--- a/generators/genutil.py
+++ b/generators/genutil.py
@@ -79,11 +79,11 @@ def isDirty(version, inputs, outputs) :
     :returns:           True if at least one output file is 'dirty'
     '''
     for output in outputs :
+        if not os.path.exists(output):
+            return True
         if version :
             if fileVersionDirty(output, version) :
                 return True
-        if not os.path.exists(output):
-            return True
         outputTime = os.path.getmtime(output)
         for input in inputs :
             inputTime = os.path.getmtime(input)


### PR DESCRIPTION
A minor QoL issue. When writing codegen scripts, I noticed a Python error if I try to delete output file(s) to force a rebuild.

It works as expected after `fips clean` or when changing the script `Version`.