### PR TITLE
Adds flag GROUP_FOLDERS to fips_files_ex

### DIFF
--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -228,6 +228,23 @@ macro(fips_add_file new_file)
 endmacro()
 
 #-------------------------------------------------------------------------------
+#   fips_dir_groups()
+#   Private helper function to add a list of files in a directory tree as groups
+#   emulating the directory tree.
+#
+macro(fips_dir_groups files)
+    foreach (_fd_file ${files})
+        get_filename_component(_fd_dir "${_fd_file}" DIRECTORY)
+        get_filename_component(_fd_name "${_fd_file}" NAME)
+        if ("${_fd_dir}" STREQUAL "")
+            set(_fd_dir ".")
+        endif()
+        fips_dir(${_fd_dir})
+        fips_add_file(${_fd_name} ".py" "NO_GENERATOR" "NO_GENFILES")
+    endforeach()
+endmacro()
+
+#-------------------------------------------------------------------------------
 #   fips_add_target_dependency(target...)
 #   Add one or more dependencies to the current target. The dependencies
 #   must be cmake build targets defined with fips_begin*/fips_end*().

--- a/site/p050_cmakeguide.md
+++ b/site/p050_cmakeguide.md
@@ -218,12 +218,12 @@ The following file extensions are recognized by the build process:
 
 fips\_files() must be called inside a module, lib, or app definition block.
 
-#### fips\_files\_ex(dir glob... \[EXCEPT glob...\] \[GROUP ide\_group\] \[NO\_RECURSE\])
+#### fips\_files\_ex(dir glob... \[EXCEPT glob...\] \[GROUP ide\_group\] \[NO\_RECURSE|GROUP\_FOLDERS\])
 
 Like fips\_dir(), but will also do a fips\_files() with files found in a directory
 that match an expression from the glob expression list excluding any file that
 is in the `EXCEPT` glob expression list. You can use `NO_RECURSE` so it will not
-search files in subdirectories. 
+search files in subdirectories. The flag `GROUP_FOLDERS` will enable the automatic creation of groups that reflect folders in the filesystem.
 
 To add all files contained in a folder but excluding some types to the group 
 "everything":
@@ -245,7 +245,7 @@ to fips.
 
 fips\_files\_ex() must be called inside a module, lib, or app definition block.
 
-#### fips\_src(dir glob... \[EXCEPT glob...\] \[GROUP ide\_group\] \[NO\_RECURSE\])
+#### fips\_src(dir glob... \[EXCEPT glob...\] \[GROUP ide\_group\] \[NO\_RECURSE|GROUP\_FOLDERS\])
 
 Same as fips\_files\_ex() but with a default list of expressions valid for C/C++
 projects: *.c *.cc *.cpp *.h *.hh *.hpp


### PR DESCRIPTION
Adds flag GROUP_FOLDERS to fips_files_ex to automatically generate groups reflecting file system folders of added files.

The GROUP_FOLDERS flag on fips_file_ex (and consequently fips_files) helps generating an ideal project group structure (eg. in a Visual Studio solution) when recursive glob is used. When doing, for example, `fips_files(. GROUP_FOLDERS)` will basically add all source files to the solution mapped exactly 
as the project folders structure on disk.

To implement this, one private helper function was needed where it iterates over a list of paths to files in the projet pushing each file to a group named after its path.

Adds this new feature documentation.

Removes some forgotten commented debug messages.