### PR TITLE
This fixes the discussed issue with GROUP_FOLDERS

### DIFF
--- a/cmake/fips.cmake
+++ b/cmake/fips.cmake
@@ -622,7 +622,7 @@ macro(fips_files_ex path)
 
     if (_fd_FILE_LIST)
         if (_fd_GROUP_FOLDERS)
-            fips_dir_groups("${_fd_FILE_LIST}")
+            fips_dir_groups("${path}" "${_fd_FILE_LIST}")
         else()
             fips_dir(${path} GROUP ${_fd_GROUP})
             fips_files(${_fd_FILE_LIST})

--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -232,14 +232,19 @@ endmacro()
 #   Private helper function to add a list of files in a directory tree as groups
 #   emulating the directory tree.
 #
-macro(fips_dir_groups files)
+macro(fips_dir_groups path files)
     foreach (_fd_file ${files})
         get_filename_component(_fd_dir "${_fd_file}" DIRECTORY)
         get_filename_component(_fd_name "${_fd_file}" NAME)
-        if ("${_fd_dir}" STREQUAL "")
-            set(_fd_dir ".")
+        if ("${path}" STREQUAL ".")
+            if ("${_fd_dir}" STREQUAL "")
+                fips_dir(".")
+            else()
+                fips_dir("${_fd_dir}") # otherise it may end as "./" and create a group "."
+            endif()
+        else()
+            fips_dir("${path}/${_fd_dir}")
         endif()
-        fips_dir(${_fd_dir})
         fips_add_file(${_fd_name} ".py" "NO_GENERATOR" "NO_GENFILES")
     endforeach()
 endmacro()


### PR DESCRIPTION
Now this have the same generated result for both `fips_src(folder GROUP_FOLDERS)`  and from inside `folder` with `fips_src(. GROUP_FOLDERS)`.