### PR TITLE
sort output of ./fips list configs

### DIFF
--- a/mod/config.py
+++ b/mod/config.py
@@ -201,6 +201,7 @@ def list(fips_dir, proj_dir, pattern) :
             fname = os.path.split(path)[1]
             fname = os.path.splitext(fname)[0]
             res[curDir].append(fname)
+        res[curDir].sort()
     return res
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Noticed that the list of configs isn't sorted anymore on Linux and MacOS. Outrageous!