### PR TITLE
Remove assumption that current project lies in the same dir as fips.

### DIFF
--- a/cmake/fips.cmake
+++ b/cmake/fips.cmake
@@ -9,8 +9,8 @@ endif()
 
 get_filename_component(FIPS_PROJECT_DIR "." ABSOLUTE)
 get_filename_component(FIPS_PROJECT_NAME ${FIPS_PROJECT_DIR} NAME)
-get_filename_component(FIPS_DEPLOY_DIR "../fips-deploy" ABSOLUTE)
-get_filename_component(FIPS_BUILD_DIR "../fips-build" ABSOLUTE)
+get_filename_component(FIPS_DEPLOY_DIR "${FIPS_ROOT_DIR}/../fips-deploy" ABSOLUTE)
+get_filename_component(FIPS_BUILD_DIR "${FIPS_ROOT_DIR}/../fips-build" ABSOLUTE)
 
 include(CMakeParseArguments)
 

--- a/mod/config.py
+++ b/mod/config.py
@@ -135,7 +135,7 @@ def get_toolchain(fips_dir, proj_dir, cfg) :
         # look for toolchain in all imported directories
         _, imported_projs = dep.get_all_imports_exports(fips_dir, proj_dir)
         for imported_proj_name in imported_projs :
-            imported_proj_dir = util.get_project_dir(fips_dir, imported_proj_name)
+            imported_proj_dir = imported_projs[imported_proj_name]['proj_dir']
             toolchain_path = '{}/fips-toolchains/{}'.format(imported_proj_dir, toolchain)
             if os.path.isfile(toolchain_path) :
                 return toolchain_path
@@ -174,7 +174,7 @@ def get_config_dirs(fips_dir, proj_dir) :
         success, result = dep.get_all_imports_exports(fips_dir, proj_dir)
         if success :
             for dep_proj_name in result :
-                dep_proj_dir = util.get_project_dir(fips_dir, dep_proj_name)
+                dep_proj_dir = result[dep_proj_name]['proj_dir']
                 dep_configs_dir = dep_proj_dir + '/fips-configs'
                 if os.path.isdir(dep_configs_dir) :
                     dirs.append(dep_configs_dir)

--- a/mod/dep.py
+++ b/mod/dep.py
@@ -142,6 +142,7 @@ def _rec_get_all_imports_exports(fips_dir, proj_dir, result) :
                     return success, result
 
         result[proj_name] = {}
+        result[proj_name]['proj_dir'] = proj_dir
         result[proj_name]['imports'] = imports 
         result[proj_name]['exports'] = exports 
 
@@ -429,7 +430,7 @@ def check_imports(fips_dir, proj_dir) :
     success, imported_projects = get_all_imports_exports(fips_dir, proj_dir)
     num_imports = 0
     for imp_proj_name in imported_projects :
-        imp_proj_dir = util.get_project_dir(fips_dir, imp_proj_name)
+        imp_proj_dir = imported_projects[imp_proj_name]['proj_dir']
 
         # don't git-check the top-level project directory
         if imp_proj_dir != proj_dir :
@@ -460,7 +461,7 @@ def check_local_changes(fips_dir, proj_dir) :
     success, imported_projects = get_all_imports_exports(fips_dir, proj_dir)
     num_imports = 0
     for imp_proj_name in imported_projects :
-        imp_proj_dir = util.get_project_dir(fips_dir, imp_proj_name)
+        imp_proj_dir = imported_projects[imp_proj_name]['proj_dir']
 
         # don't git-check the top-level project directory
         if imp_proj_dir != proj_dir :

--- a/mod/verb.py
+++ b/mod/verb.py
@@ -59,7 +59,7 @@ def import_verbs(fips_dir, proj_dir) :
     if fips_dir != proj_dir :
         _, imported_projs = dep.get_all_imports_exports(fips_dir, proj_dir)
         for imported_proj_name in imported_projs :
-            imported_proj_dir = util.get_project_dir(fips_dir, imported_proj_name)
+            imported_proj_dir = imported_projs[imported_proj_name]['proj_dir']
             import_verbs_from(imported_proj_name, imported_proj_dir, imported_proj_dir + '/fips-verbs')
 
     


### PR DESCRIPTION
Specifically for fips-configs, fips-toolchains, and fips-verbs logic.