### PR TITLE
Makes it possible to switch to the dynamic CRT.

### DIFF
--- a/cmake-toolchains/windows.cmake
+++ b/cmake-toolchains/windows.cmake
@@ -66,6 +66,13 @@ if (FIPS_EXCEPTIONS)
 else()
     set(FIPS_VS_EXCEPTION_FLAGS "/EHsc")
 endif()
+
+if (FIPS_DYNAMIC_CRT)
+    set(FIPS_VS_CRT_FLAGS "/MD")
+else()
+    set(FIPS_VS_CRT_FLAGS "/MT")
+endif()
+
 set(CMAKE_CXX_FLAGS "${FIPS_VS_EXCEPTION_FLAGS} /MP /WX /TP /DWIN32")
 set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Od /Oy- /D_DEBUG /DFIPS_DEBUG=1")
 set(CMAKE_CXX_FLAGS_RELEASE "/Ox /DNDEBUG")
@@ -74,9 +81,8 @@ if (FIPS_UWP)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd /ZW")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MD /ZW")
 else()
-    # on Win32, link runtime statically 
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FIPS_VS_CRT_FLAGS}d")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${FIPS_VS_CRT_FLAGS}")
 endif()
 
 set(CMAKE_C_FLAGS "/MP /WX /TC /errorReport:queue /DWIN32")
@@ -86,10 +92,9 @@ if (FIPS_UWP)
     # must link runtime as DLLs
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MDd /ZW")
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MD /ZW")
-else()
-    # on Win32, link runtime statically 
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+else() 
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${FIPS_VS_CRT_FLAGS}d")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${FIPS_VS_CRT_FLAGS}")
 endif()
 
 # define exe linker flags

--- a/site/p050_cmakeguide.md
+++ b/site/p050_cmakeguide.md
@@ -115,14 +115,14 @@ This finishes a fips\_begin\_lib() block.
 Begin defining a fips shared library. A fips shared library is a collection of source
 files that compile into a dynamically linkable library (as opposed to static libraries).
 
-After a fips\_begin\_lib() the following fips macros are valid:
+After a fips\_begin\_sharedlib() the following fips macros are valid:
 
 * fips\_dir()
 * fips\_files()
 * fips\_generate()
 * fips\_deps()
 * fips\_libs()
-* fips\_end\_lib()
+* fips\_end\_sharedlib()
 
 #### fips\_end\_sharedlib()
 


### PR DESCRIPTION
If FIPS_DYNAMIC_CRT is set, VS compiler will use /MD and /MDd instead /MT and /MTd for Windows/VS compilation. The default behavior is still MT.

This is required because setting one own project to use MD will not work if the project has any fips import as the imports will all be MT.

By setting FIPS_DYNAMIC_CRT before including fips.cmake every import will use the same runtime.

Fix a typo in the docs.