### PR TITLE
Fix Python3 issue

### DIFF
--- a/mod/tools/node.py
+++ b/mod/tools/node.py
@@ -10,7 +10,7 @@ not_found = 'node.js required for emscripten cross-compiling'
 def check_exists(fips_dir) :
     try :
         out = subprocess.check_output(['node', '--version'])
-        if not out.startswith('v') :
+        if not out.startswith(b'v') :
             log.warn("this doesn't look like a proper node.js 'node'")
             return False 
         return True


### PR DESCRIPTION
The 'out' var is a byte string, so it expects the same type as the argument to startwith.