### PR TITLE
less verbose msbuild output, added num_jobs parameter

### DIFF
--- a/mod/project.py
+++ b/mod/project.py
@@ -253,8 +253,8 @@ def build(fips_dir, proj_dir, cfg_name, target=None) :
                 elif cfg['build_tool'] == xcodebuild.name :
                     result = xcodebuild.run_build(fips_dir, target, cfg['build_type'], build_dir, num_jobs)
                 else :
-                    result = cmake.run_build(fips_dir, target, cfg['build_type'], build_dir)
-                
+                    result = cmake.run_build(fips_dir, target, cfg['build_type'], build_dir, num_jobs)
+
                 if result :
                     num_valid_configs += 1
                 else :

--- a/mod/tools/cmake.py
+++ b/mod/tools/cmake.py
@@ -69,17 +69,22 @@ def run_gen(cfg, fips_dir, project_dir, build_dir, toolchain_path, defines) :
     return res == 0
 
 #------------------------------------------------------------------------------
-def run_build(fips_dir, target, build_type, build_dir) :
+def run_build(fips_dir, target, build_type, build_dir, num_jobs=1) :
     """run cmake in build mode
 
     :param target:          build target, can be None (builds all)
     :param build_type:      CMAKE_BUILD_TYPE string (e.g. Release, Debug)
     :param build_dir:       path to the build directory
+    :param num_jobs:        number of parallel jobs (default: 1)
     :returns:               True if cmake returns successful
     """
     cmdLine = 'cmake --build . --config {}'.format(build_type)
     if target :
         cmdLine += ' --target {}'.format(target)
+    if platform.system() == 'Windows' :
+        cmdLine += ' -- /nologo /verbosity:minimal /maxcpucount:{}'.format(num_jobs)
+    else :
+        cmdLine += ' -- -j{}'.format(num_jobs)
     print(cmdLine)
     res = subprocess.call(cmdLine, cwd=build_dir, shell=True)
     return res == 0


### PR DESCRIPTION
Passes the `num_jobs` parameter to cmake, just like the other build tools.

Also makes the output less verbose when compiling with msbuild. There's still that "CMake does not need to re-run because..." spam, but the only other/less verbose level is "quiet", which doesn't give _any_ progress indicator at all.