### PR TITLE
CLion IDE support

### DIFF
--- a/cmake/fips.cmake
+++ b/cmake/fips.cmake
@@ -103,7 +103,7 @@ macro(fips_setup)
 
     # set FIPS_CONFIG to default if not provided by command line
     # (this provides better compatibility with some IDEs not directly
-    # supported by cmake, like QtCreator or CLion
+    # supported by cmake, like QtCreator
     if (NOT FIPS_CONFIG)
         message("FIPS_CONFIG not provided by command line, selecting default value")
         fips_choose_config()

--- a/configs/linux-clion-debug.yml
+++ b/configs/linux-clion-debug.yml
@@ -1,0 +1,5 @@
+---
+platform: linux 
+generator: Unix Makefiles
+build_tool: clion
+build_type: Debug

--- a/configs/linux-clion-release.yml
+++ b/configs/linux-clion-release.yml
@@ -1,0 +1,5 @@
+---
+platform: linux 
+generator: Unix Makefiles
+build_tool: clion
+build_type: Release

--- a/configs/osx-clion-debug.yml
+++ b/configs/osx-clion-debug.yml
@@ -1,0 +1,5 @@
+---
+platform: osx 
+generator: Unix Makefiles
+build_tool: clion
+build_type: Debug

--- a/configs/osx-clion-release.yml
+++ b/configs/osx-clion-release.yml
@@ -1,0 +1,5 @@
+---
+platform: osx 
+generator: Unix Makefiles
+build_tool: clion
+build_type: Release

--- a/mod/config.py
+++ b/mod/config.py
@@ -5,7 +5,7 @@ import glob
 import yaml
 from collections import OrderedDict
 from mod import log, util, dep
-from mod.tools import cmake, make, ninja, xcodebuild, vscode
+from mod.tools import cmake, make, ninja, xcodebuild, vscode, clion
 from mod import emscripten, nacl, android
 
 # non-cross-compiling platforms
@@ -21,7 +21,8 @@ build_tools = [
     'ninja',
     'xcodebuild',
     'cmake',
-    'vscode_cmake'
+    'vscode_cmake',
+    'clion'
 ]
 
 default_config = {
@@ -216,6 +217,8 @@ def check_build_tool(fips_dir, tool_name) :
         return xcodebuild.check_exists(fips_dir)
     elif tool_name == 'vscode_cmake' :
         return vscode.check_exists(fips_dir)
+    elif tool_name == 'clion' :
+        return clion.check_exists(fips_dir)
     else :
         return False;
 

--- a/mod/project.py
+++ b/mod/project.py
@@ -6,7 +6,7 @@ import subprocess
 import yaml
 
 from mod import log, util, config, dep, template, settings, android
-from mod.tools import git, cmake, make, ninja, xcodebuild, ccmake, cmake_gui, vscode
+from mod.tools import git, cmake, make, ninja, xcodebuild, ccmake, cmake_gui, vscode, clion
 
 #-------------------------------------------------------------------------------
 def init(fips_dir, proj_name) :
@@ -26,7 +26,7 @@ def init(fips_dir, proj_name) :
         for f in ['CMakeLists.txt', 'fips', 'fips.cmd', 'fips.yml'] :
             template.copy_template_file(fips_dir, proj_dir, f, templ_values)
         os.chmod(proj_dir + '/fips', 0o744)
-        gitignore_entries = ['.fips-*', '*.pyc', '.vscode/']
+        gitignore_entries = ['.fips-*', '*.pyc', '.vscode/', '.idea/']
         template.write_git_ignore(proj_dir, gitignore_entries)
     else :
         log.error("project dir '{}' does not exist".format(proj_dir))
@@ -90,6 +90,8 @@ def gen_project(fips_dir, proj_dir, cfg, force) :
         cmake_result = cmake.run_gen(cfg, fips_dir, proj_dir, build_dir, toolchain_path, defines)
         if cfg['build_tool'] == 'vscode_cmake':
             vscode.write_workspace_settings(fips_dir, proj_dir, cfg)
+        if cfg['build_tool'] == 'clion':
+            clion.write_workspace_settings(fips_dir, proj_dir, cfg)
         return cmake_result
     else :
         return True

--- a/mod/tools/__init__.py
+++ b/mod/tools/__init__.py
@@ -1,4 +1,4 @@
 """command line tool wrapper scripts"""
 
-__all__ = ['cmake','ccmake','cmake_gui','make','ninja','xcodebuild','vscode']
+__all__ = ['cmake','ccmake','cmake_gui','make','ninja','xcodebuild','vscode','clion']
 

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -13,19 +13,37 @@ def check_exists(fips_dir) :
     """test if 'clion' is in the path
     :returns:   True if clion is in the path
     """
-    try:
-        subprocess.check_output("snap list | grep 'clion'", shell=True)
-        return True
-    except (OSError, subprocess.CalledProcessError):
+    host = util.get_host_platform()
+    if host == 'linux':
+        try:
+            subprocess.check_output("snap list | grep 'clion'", shell=True)
+            return True
+        except (OSError, subprocess.CalledProcessError):
+            return False
+    elif host == 'osx':
+        try:
+            subprocess.check_output("mdfind -name CLion.app | grep 'CLion'", shell=True)
+            return True
+        except (OSError, subprocess.CalledProcessError):
+            return False
+    else:
         return False
 
 #------------------------------------------------------------------------------
 def run(proj_dir):
-    try:
-        proj_name = util.get_project_name_from_dir(proj_dir)
-        subprocess.Popen('clion {}'.format(proj_dir), cwd=proj_dir, shell=True)
-    except OSError:
-        log.error("Failed to run JetBrains CLion as 'clion'") 
+    host = util.get_host_platform()
+    if host == 'linux':
+        try:
+            subprocess.Popen('clion {}'.format(proj_dir), cwd=proj_dir, shell=True)
+        except OSError:
+            log.error("Failed to run JetBrains CLion as 'clion'")
+    elif host == 'osx':
+        try:
+            subprocess.Popen('open /Applications/CLion.app --args {}'.format(proj_dir), cwd=proj_dir, shell=True)
+        except OSError:
+            log.error("Failed to run JetBrains CLion as '/Applications/CLion.app'")
+    else:
+        log.error("Not supported on this platform")
 
 #-------------------------------------------------------------------------------
 def write_clion_module_files(fips_dir, proj_dir, cfg):

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -1,6 +1,6 @@
 '''CLion helper functions'''
-import subprocess, os, yaml, json, inspect, tempfile, glob, shutil
-from mod import util,log,verb,dep
+import subprocess, os, shutil
+from mod import util, log, verb, dep
 from mod.tools import cmake
 
 name = 'clion'
@@ -85,13 +85,13 @@ def write_clion_workspace_file(fips_dir, proj_dir, cfg):
     with open(ws_path, 'w') as f:
         f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         f.write('<project version="4">\n')
-        #CMakeRunConfigurationManager
+        # TODO: CMakeRunConfigurationManager
         f.write('  <component name="CMakeSettings">\n')
         f.write('    <configurations>\n')
         f.write('      <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" GENERATION_OPTIONS="{}" GENERATION_DIR="{}" />\n'.format(gen_options, gen_dir))
         f.write('    </configurations>\n')
         f.write('  </component>\n')
-        #RunManager
+        # TODO: RunManager
         f.write('</project>')
 
 #-------------------------------------------------------------------------------
@@ -104,3 +104,20 @@ def write_workspace_settings(fips_dir, proj_dir, cfg):
         os.makedirs(clion_dir)
     write_clion_module_files(fips_dir, proj_dir, cfg)
     write_clion_workspace_file(fips_dir, proj_dir, cfg)
+
+#-------------------------------------------------------------------------------
+def cleanup(fips_dir, proj_dir):
+    '''deletes the .idea directory'''
+    clion_dir = proj_dir + '/.idea'
+    if os.path.isdir(clion_dir):
+        log.info(log.RED + 'Please confirm to delete the following directory:' + log.DEF)
+        log.info('  {}'.format(clion_dir))
+        if util.confirm(log.RED + 'Delete this directory?' + log.DEF):
+            if os.path.isdir(clion_dir):
+                log.info('  deleting {}'.format(clion_dir))
+                shutil.rmtree(clion_dir)
+            log.info('Done.')
+        else:
+            log.info('Nothing deleted, done.')
+    else:
+        log.info('Nothing to delete.')

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -1,0 +1,88 @@
+'''CLion helper functions'''
+import subprocess, os, yaml, json, inspect, tempfile, glob, shutil
+from mod import util,log,verb,dep
+from mod.tools import cmake
+
+name = 'clion'
+platforms = ['osx','linux','win']
+optional = True
+not_found = 'used as IDE with clion configs'
+
+#------------------------------------------------------------------------------
+def check_exists(fips_dir) :
+    """test if 'clion' is in the path
+    :returns:   True if clion is in the path
+    """
+    try:
+        subprocess.check_output("snap list | grep 'clion'", shell=True)
+        return True
+    except (OSError, subprocess.CalledProcessError):
+        return False
+
+#------------------------------------------------------------------------------
+def run(proj_dir):
+    try:
+        proj_name = util.get_project_name_from_dir(proj_dir)
+        subprocess.Popen('clion {}'.format(proj_dir), cwd=proj_dir, shell=True)
+    except OSError:
+        log.error("Failed to run JetBrains CLion as 'clion'") 
+
+#-------------------------------------------------------------------------------
+def write_clion_module_files(fips_dir, proj_dir, cfg):
+    '''write misc.xml, modules.xml, *.iml'''
+    proj_name = util.get_project_name_from_dir(proj_dir)
+    iml_path = '{}/.idea/{}.iml'.format(proj_dir, proj_name)
+    if os.path.exists(iml_path):
+        return
+    with open(iml_path, 'w') as f:
+        f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        f.write('<module classpath="CMake" type="CPP_MODULE" version="4" />')
+    ws_path = '{}/.idea/misc.xml'.format(proj_dir)
+    with open(ws_path, 'w') as f:
+        f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        f.write('<project version="4">\n')
+        f.write('  <component name="CMakeWorkspace" IGNORE_OUTSIDE_FILES="true" PROJECT_DIR="$PROJECT_DIR$" />\n')
+        f.write('</project>')
+    ws_path = '{}/.idea/modules.xml'.format(proj_dir)
+    with open(ws_path, 'w') as f:
+        f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        f.write('<project version="4">\n')
+        f.write('  <component name="ProjectModuleManager">\n')
+        f.write('    <modules>\n')
+        f.write('      <module fileurl="file://$PROJECT_DIR$/.idea/{}.iml" filepath="$PROJECT_DIR$/.idea/{}.iml" />\n'.format(proj_name, proj_name))
+        f.write('    </modules>\n')
+        f.write('  </component>\n')
+        f.write('</project>')
+
+#-------------------------------------------------------------------------------
+def write_clion_workspace_file(fips_dir, proj_dir, cfg):
+    '''write bare-bone workspace.xml config file'''
+    proj_name = util.get_project_name_from_dir(proj_dir)
+    gen_options = '-DFIPS_CONFIG={}'.format(cfg['name'])
+    gen_dir = '$PROJECT_DIR$/../fips-build/{}/{}'.format(proj_name, cfg['name'])
+    ws_path = '{}/.idea/workspace.xml'.format(proj_dir)
+    # do not overwrite existing .xml
+    if os.path.exists(ws_path):
+        return
+    with open(ws_path, 'w') as f:
+        f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+        f.write('<project version="4">\n')
+        #CMakeRunConfigurationManager
+        f.write('  <component name="CMakeSettings">\n')
+        f.write('    <configurations>\n')
+        f.write('      <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" GENERATION_OPTIONS="{}" GENERATION_DIR="{}" />\n'.format(gen_options, gen_dir))
+        f.write('    </configurations>\n')
+        f.write('  </component>\n')
+        #RunManager
+        f.write('</project>')
+
+#-------------------------------------------------------------------------------
+def write_workspace_settings(fips_dir, proj_dir, cfg):
+    '''write the CLion *.xml files required to open the project
+    '''
+    log.info("=== writing JetBrains CLion config files...")
+    clion_dir = proj_dir + '/.idea'
+    if not os.path.isdir(clion_dir):
+        os.makedirs(clion_dir)
+    write_clion_module_files(fips_dir, proj_dir, cfg)
+    write_clion_workspace_file(fips_dir, proj_dir, cfg)

--- a/verbs/clion.py
+++ b/verbs/clion.py
@@ -1,0 +1,24 @@
+"""helper verb for CLion support
+
+clion clean     -- removes all .idea directories in all dependencies
+"""
+from mod import log, util
+from mod.tools import clion
+
+#-------------------------------------------------------------------------------
+def run(fips_dir, proj_dir, args) :
+    if not util.is_valid_project_dir(proj_dir) :
+        log.error('must be run in a project directory')
+    if len(args) > 0:
+        if args[0] == 'clean':
+            clion.cleanup(fips_dir, proj_dir)
+        else:
+            log.error("invalid noun '{}' (expected: clean)".format(noun))
+
+#-------------------------------------------------------------------------------
+def help():
+    log.info(log.YELLOW +
+             "fips clion clean\n"
+             + log.DEF +
+             "    delete the .idea directory (useful before git\n" +
+             "    operations, or when switching build configs)")

--- a/verbs/diag.py
+++ b/verbs/diag.py
@@ -7,7 +7,7 @@ diag imports    -- check all imports
 diag            -- same as 'diag all'
 """
 
-from mod.tools import git, cmake, ccmake, cmake_gui, python2, vscode
+from mod.tools import git, cmake, ccmake, cmake_gui, python2, vscode, clion
 from mod.tools import make, ninja, xcodebuild, java, javac, node, ccache
 from mod import config, util, log, dep
 
@@ -24,7 +24,7 @@ def check_fips(fips_dir) :
 def check_tools(fips_dir) :
     """check whether required command line tools can be found"""
     log.colored(log.YELLOW, '=== tools:')
-    tools = [ git, cmake, ccmake, cmake_gui, make, ninja, xcodebuild, javac, java, node, python2, ccache, vscode ]
+    tools = [ git, cmake, ccmake, cmake_gui, make, ninja, xcodebuild, javac, java, node, python2, ccache, vscode, clion ]
     platform = util.get_host_platform()
     for tool in tools:
         if platform in tool.platforms :

--- a/verbs/open.py
+++ b/verbs/open.py
@@ -9,7 +9,7 @@ import glob
 import subprocess
 
 from mod import log, util, settings, config, project
-from mod.tools import vscode
+from mod.tools import vscode, clion
 
 #-------------------------------------------------------------------------------
 def run(fips_dir, proj_dir, args) :
@@ -39,6 +39,10 @@ def run(fips_dir, proj_dir, args) :
         # first check if this is a VSCode project
         if cfg['build_tool'] == 'vscode_cmake':
             vscode.run(proj_dir)
+            return
+        # check if this is a CLion project
+        if cfg['build_tool'] == 'clion':
+            clion.run(proj_dir)
             return
         # try to open as Xcode project
         proj = glob.glob(build_dir + '/*.xcodeproj')


### PR DESCRIPTION
I got me a personal license recently, so I looked into streamlining its use with fips. With this PR some minimal workspace configuration is written to `$project_dir/.idea/`, which is then nourished by CLion when the project is loaded.

I didn't bother to generate a complete workspace config, so there's some room for improvement:

- in the project browser, all _generated_ source files are put into the root folder
- CLion detects and adds run/debug configurations by itself, but `fips run` settings (cwd, arguments) are not yet considered

Other known issues:

- `fips open` (and `fips diag tools`) works on Linux by asking `snap`, which is used when installing from Ubuntu's "app store". It won't work when downloading and installing CLion manually. On OSX, it expects CLion to be installed in `/Applications/CLion.app`.
- No Windows support. CLion MSVC support is pretty weird. I didn't try with MinGW yet.