### PR TITLE
Add fips init to documentation

### DIFF
--- a/site/p010_getstarted.md
+++ b/site/p010_getstarted.md
@@ -100,3 +100,22 @@ python2:	found
 > NOTE that some tools are optional and only required for specific 
 build configurations
 
+### Setup new project
+
+A new fips project can be setup by running './fips init path/to/project'. This will copy a few commonly used fips config files into the target project directory. From the fips directory run './fips init project-1' and the following will be setup for you:
+
+{% highlight bash %}
+┗━━ fips-workspace/
+    ┗━━ fips/
+    ┃   ┗━━ ...
+    ┗━━ project-1/
+        ┣━━ fips.yml 
+        ┣━━ fips 
+        ┣━━ fips.cmd 
+        ┣━━ CMakeLists.txt 
+        ┗━━ .gitignore
+{% endhighlight %}
+
+> NOTE fips will look for the folder in the root of the fipsified project (in this case the fips-workspace created above) and not in the fips folder itself. 
+
+From now on you can run all fips commands directly in the new project's directory.


### PR DESCRIPTION
This adds a short paragraph to the Get Started section to explain setting up a new project with fips init. I wasn't able to preview the changes as I'm not really sure what the process is you go through to get the html out for the gh-pages branch. I think I got it right though :)

Happy to do a proper preview first if you enlighten me.