### PR TITLE
Improving CLion detection in Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 script:
     - echo $TRAVIS_OS_NAME
     - git --version
+    - python --version
     # test fips command itself
     - python fips
     # clone hello world project

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -22,7 +22,7 @@ def check_exists(fips_dir) :
         # This will also pick up CLion if it was installed using snap.
         if find_executable("clion.sh") is not None or find_executable("clion") is not None:
             return True
-        else
+        else:
             return False
     elif host == 'osx':
         try:

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -19,15 +19,9 @@ def check_exists(fips_dir) :
         # See if CLion was installed from a tar.gz and manually added to the path ("clion.sh"),
         # or added to the path using the "create launcher" command in CLion, which would by default
         # create a symlink from clion.sh to /usr/local/bin/clion.
+        # This will also pick up CLion if it was installed using snap.
         if find_executable("clion.sh") is not None or find_executable("clion") is not None:
             return True
-        else:
-            try:
-                # See if CLion was installed using snap
-                subprocess.check_output("snap list | grep 'clion'", shell=True)
-                return True
-            except (OSError, subprocess.CalledProcessError):
-                return False
     elif host == 'osx':
         try:
             subprocess.check_output("mdfind -name CLion.app | grep 'CLion'", shell=True)

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -22,6 +22,8 @@ def check_exists(fips_dir) :
         # This will also pick up CLion if it was installed using snap.
         if find_executable("clion.sh") is not None or find_executable("clion") is not None:
             return True
+        else
+            return False
     elif host == 'osx':
         try:
             subprocess.check_output("mdfind -name CLion.app | grep 'CLion'", shell=True)

--- a/mod/tools/clion.py
+++ b/mod/tools/clion.py
@@ -2,6 +2,7 @@
 import subprocess, os, shutil
 from mod import util, log, verb, dep
 from mod.tools import cmake
+from distutils.spawn import find_executable
 
 name = 'clion'
 platforms = ['osx','linux','win']
@@ -18,7 +19,7 @@ def check_exists(fips_dir) :
         # See if CLion was installed from a tar.gz and manually added to the path ("clion.sh"),
         # or added to the path using the "create launcher" command in CLion, which would by default
         # create a symlink from clion.sh to /usr/local/bin/clion.
-        if shutil.which("clion.sh") is not None or shutil.which("clion") is not None:
+        if find_executable("clion.sh") is not None or find_executable("clion") is not None:
             return True
         else:
             try:
@@ -41,7 +42,7 @@ def run(proj_dir):
     host = util.get_host_platform()
     if host == 'linux':
         try:
-            if shutil.which("clion.sh") is not None:
+            if find_executable("clion.sh") is not None:
                 subprocess.Popen('clion.sh {}'.format(proj_dir), cwd=proj_dir, shell=True)
             else:
                 subprocess.Popen('clion {}'.format(proj_dir), cwd=proj_dir, shell=True)


### PR DESCRIPTION
Updated CLion detection in Linux to no longer require snap.  As long as "clion" or "clion.sh" are part of the system path, the detection will now pass.