### PR TITLE
Allow rotation in default Android manifest

### DIFF
--- a/tools/android-create-apk.py
+++ b/tools/android-create-apk.py
@@ -117,8 +117,8 @@ with open(apk_dir + 'AndroidManifest.xml', 'w') as f:
     f.write('    <activity android:name="android.app.NativeActivity"\n');
     f.write('      android:label="{}"\n'.format(args.name))
     f.write('      android:launchMode="singleTask"\n')
-    f.write('      android:screenOrientation="landscape"\n')
-    f.write('      android:configChanges="orientation|keyboardHidden">\n')
+    f.write('      android:screenOrientation="fullUser"\n')
+    f.write('      android:configChanges="orientation|screenSize|keyboard|keyboardHidden">\n')
     f.write('      <meta-data android:name="android.app.lib_name" android:value="{}"/>\n'.format(args.name))
     f.write('      <intent-filter>\n')
     f.write('        <action android:name="android.intent.action.MAIN"/>\n')


### PR DESCRIPTION
I don't know how well this plays with oryol but it should work fine with floooh/sokol#87.

I had a line of code for stripping dashes from package names as well but that seems to have been fixed in the master branch so I left it out.