### PR TITLE
Use correct cmake variable for emscripten root folder

### DIFF
--- a/cmake-toolchains/emscripten.toolchain.cmake
+++ b/cmake-toolchains/emscripten.toolchain.cmake
@@ -178,7 +178,7 @@ set(CMAKE_LINKER "${EMSCRIPTEN_ROOT}/emcc${EMCC_SUFFIX}" CACHE PATH "linker" FOR
 set(CMAKE_RANLIB "${EMSCRIPTEN_ROOT}/emranlib${EMCC_SUFFIX}" CACHE PATH "ranlib" FORCE)
 
 # override cmake modules with emscripten cmake modules
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${EMSCRIPTEN_ROOT_PATH}/cmake/Modules")
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${EMSCRIPTEN_ROOT}/cmake/Modules")
 
 # only search for libraries and includes in the toolchain
 set(CMAKE_FIND_ROOT_PATH ${EMSCRIPTEN_ROOT})


### PR DESCRIPTION
Sorry, in my last PR I didn't take into account that the emscripten-root variable had a recent name change, should've tested it better.

If you wan to test this yourself I created a very small test project: https://github.com/GeertArien/fips-endian-test

When generating one of the emscripten configs it should throw the following error or similar (only first run or after ./fips clean):
`CMake Error at /**/TestBigEndian.cmake:106 (message):
  TEST_BIG_ENDIAN found no result!
Call Stack (most recent call first):
  code/CMakeLists.txt:3 (test_big_endian)`

This PR should fix that.