### PR TITLE
option in fips.yml to conditionally export include paths

### DIFF
--- a/mod/dep.py
+++ b/mod/dep.py
@@ -66,8 +66,8 @@ def get_exports(proj_dir) :
             exports = dic['exports']
     if not 'header-dirs' in exports :
         exports['header-dirs'] = []
-    if not 'platform-header-dirs' in exports :
-        exports['platform-header-dirs'] = {}
+    if not 'conditional-header-dirs' in exports :
+        exports['conditional-header-dirs'] = []
     if not 'lib-dirs' in exports :
         exports['lib-dirs'] = []
     if not 'defines' in exports :
@@ -110,7 +110,7 @@ def _rec_get_all_imports_exports(fips_dir, proj_dir, result) :
             url:    git-url (not valid for first, top-level project)
             exports:
                 header-dirs: [ ]
-                platform-header-dirs:
+                conditional-header-dirs:
                     dir: cmake-if condition string
                 lib-dirs: [ ]
                 defines: 
@@ -278,14 +278,19 @@ def gather_imports(fips_dir, proj_dir) :
                         log.warn("header search path '{}' not found in project '{}'".format(hdr_path, imp_proj_name))
                     imported[imp_proj_name]['hdrdirs'].append(hdr_path)
 
-                # add platform (conditional) header search paths
-                for imp_hdr in deps[imp_proj_name]['exports']['platform-header-dirs'] :
-                    hdr_path = '{}/{}/{}'.format(ws_dir, imp_proj_name, imp_hdr)
-                    hdr_path = os.path.normpath(hdr_path).replace('\\', '/')
-                    if not os.path.isdir(hdr_path) :
-                        log.warn("platform header search path '{}' not found in project '{}'".format(hdr_path, imp_proj_name))
-                    value = deps[imp_proj_name]['exports']['platform-header-dirs'][imp_hdr]
-                    imported[imp_proj_name]['condhdrdirs'][hdr_path] = value
+                # add conditional header search paths
+                for imp_hdr in deps[imp_proj_name]['exports']['conditional-header-dirs'] :
+                    if not 'path' in imp_hdr :
+                        log.warn("no 'path' key in conditional-header-dirs in project {}".format(imp_proj_name))
+                    elif not 'cond' in imp_hdr :
+                        log.warn("no 'cond' key in conditional-header-dirs in project {}".format(imp_proj_name))
+                    else :
+                        hdr_path = '{}/{}/{}'.format(ws_dir, imp_proj_name, imp_hdr['path'])
+                        hdr_path = os.path.normpath(hdr_path).replace('\\', '/')
+                        if not os.path.isdir(hdr_path) :
+                            log.warn("conditional header search path '{}' not found in project '{}'".format(hdr_path, imp_proj_name))
+                        value = imp_hdr['cond']
+                        imported[imp_proj_name]['condhdrdirs'][hdr_path] = value
 
                 # add lib search paths
                 for imp_lib in deps[imp_proj_name]['exports']['lib-dirs'] :


### PR DESCRIPTION
I'm creating this PR as a follow-up to my rant on Twitter. It adds an option to `fips.yml` to export header paths based on CMake conditions, similar to the `cond` parameter for imports.

~~~
---
exports:
  platform-header-dirs:
    include: "FIPS_OSX"
    include/SDL2: "FIPS_WINDOWS"
    # no Linux here, uses find_package(SDL2 REQUIRED)
~~~

Naming and YML format are subject for discussion! ;)