### PR TITLE
bugfix: files without extension will crash fips_files()

### DIFF
--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -232,7 +232,7 @@ macro(fips_add_file new_file)
         # add to current source group
         source_group("${CurGroup}" FILES ${cur_file})
 
-        if (FIPS_OSX)
+        if (FIPS_OSX AND ${f_ext})
             # mark .m as .c file for older cmake versions (bug is fixed in cmake 3.1+)
             if (${f_ext} STREQUAL ".m")
                 set_source_files_properties(${cur_file} PROPERTIES LANGUAGE C)


### PR DESCRIPTION

Adding a file with fips_files(filname) will break on line 237 in fips_private.cmake if filename has no extension. This PR adds a check to see if the variable exists before comparing it.

You probably only expected source files to be added here. I'm using the code below to add my data resource files to a macOS app bundle. Your could perhaps use this code inside fips as well, but I wasn't sure exactly where to add this feature. 


CMakeList.txt somewhere:
```
if (FIPS_MACOS)
    file(GLOB_RECURSE resources_data
            "${CMAKE_CURRENT_SOURCE_DIR}/data/*"
            )
endif()
```

Later inside fips_begin_app()
```
    if (FIPS_MACOS)
        fips_dir(.)
        foreach(res_file ${resources_data})
            # add to project
            fips_files(${res_file})
            # get the relative path and set location in app package (under Resources)
            file(RELATIVE_PATH res_rel_path "${CMAKE_CURRENT_SOURCE_DIR}" ${res_file})
            get_filename_component(res_path ${res_rel_path} DIRECTORY)
            set_property(SOURCE ${res_file} PROPERTY MACOSX_PACKAGE_LOCATION "Resources/${res_path}")
        endforeach(res_file)
    endif()
```
