### PR TITLE
handle empty extension, better solution

### DIFF
--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -233,16 +233,14 @@ macro(fips_add_file new_file)
         source_group("${CurGroup}" FILES ${cur_file})
 
         if (FIPS_OSX)
-            if (${f_ext})
-                # mark .m as .c file for older cmake versions (bug is fixed in cmake 3.1+)
-                if (${f_ext} STREQUAL ".m")
-                    set_source_files_properties(${cur_file} PROPERTIES LANGUAGE C)
-                endif()
+            # mark .m as .c file for older cmake versions (bug is fixed in cmake 3.1+)
+            if ("${f_ext}" STREQUAL ".m")
+                set_source_files_properties(${cur_file} PROPERTIES LANGUAGE C)
+            endif()
 
-                # handle plist files special
-                if (${f_ext} STREQUAL ".plist")
-                    set(FIPS_OSX_PLIST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${cur_file}")
-                endif()
+            # handle plist files special
+            if ("${f_ext}" STREQUAL ".plist")
+                set(FIPS_OSX_PLIST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${cur_file}")
             endif()
         endif()
 


### PR DESCRIPTION
Sorry for all the PR, but I don't want to make your code worse. I did some more research, and this is the proper solution that should work in all cmakes. 

```if (${f_ext} STREQUAL ".m")```
```if ("${f_ext}" STREQUAL ".m")```

expands to 

```if ( STREQUAL ".m")```
```if ("" STREQUAL ".m")```

when f_ext is the empty string. 

Complications in first case: If f_ext has a value of say "ext" _and_ there is a variable with name ext, cmake then takes the value of that variable into the if statement. If there isn't a variable named ext, ext is converted to the string "ext". So, adding "" around ${} is the safe way.

I'm mostly on very modern CMake versions btw, VS2019 is only supported in 3.15+
