### PR TITLE
Fixed incorrect log colors + Improvements to generation time for VSCode on Windows

### DIFF
--- a/mod/log.py
+++ b/mod/log.py
@@ -2,11 +2,11 @@
 import sys
 
 # log colors
-RED = '\033[31m'
-GREEN = '\033[32m'
-YELLOW = '\033[33m'
-BLUE = '\033[36m'
-DEF = '\033[39m'
+RED = '\033[1;31m'
+GREEN = '\033[1;32m'
+YELLOW = '\033[1;33m'
+BLUE = '\033[1;36m'
+DEF = '\033[0;0m'
 
 #-------------------------------------------------------------------------------
 def error(msg, fatal=True) :
@@ -49,7 +49,7 @@ def optional(item, status) :
     """print a yellow 'optional' message
 
     :param item:    first part of message
-    :param status:  status (colored red)
+    :param status:  status (colored yellow)
     """
     print('{}:\t{}{}{}'.format(item, YELLOW, status, DEF))
 

--- a/mod/tools/vscode.py
+++ b/mod/tools/vscode.py
@@ -179,7 +179,7 @@ def get_vs_header_paths(fips_dir, proj_dir, cfg):
     # next get the used active Visual Studio instance from the cmake cache
     proj_name = util.get_project_name_from_dir(proj_dir)
     build_dir = util.get_build_dir(fips_dir, proj_name, cfg['name'])
-    outp = subprocess.check_output(['cmake', '-LA', '.'], cwd=build_dir).decode("utf-8")
+    outp = subprocess.check_output(['cmake', '-LA', '-N', '.'], cwd=build_dir).decode("utf-8")
     for line in outp.splitlines():
         if line.startswith('CMAKE_LINKER:FILEPATH='):
             bin_index = line.find('/bin/')


### PR DESCRIPTION
Log colors has always been wonky for me: GREEN and RED has worked, but no other colors.
I've changed the color codes, and it seems much more reliable now.

I've tested it in powershell, cmd, debian default terminal and afaik, it works fine.

edit: Also tested in both python 2 and 3