### PR TITLE
Added vscode_exclude_from_workspace config setting.

### DIFF
--- a/mod/tools/vscode.py
+++ b/mod/tools/vscode.py
@@ -442,7 +442,14 @@ def write_code_workspace_file(fips_dir, proj_dir, impex, cfg):
     # add dependencies in reverse order, so that main project is first
     for dep_proj_name in reversed(impex):
         dep_proj_dir = util.get_project_dir(fips_dir, dep_proj_name)
-        ws['folders'].append({ 'path': dep_proj_dir })
+        excluded = False
+        if 'vscode_exclude_from_workspace' in cfg:
+            for exclude_dep in cfg['vscode_exclude_from_workspace']:
+                if dep_proj_name == exclude_dep:
+                    excluded = True
+                    break
+        if not excluded:
+            ws['folders'].append({ 'path': dep_proj_dir })
     proj_name = util.get_project_name_from_dir(proj_dir)
     ws_path = '{}/{}.code-workspace'.format(vscode_dir, proj_name) 
     log.info('  writing {}'.format(ws_path))


### PR DESCRIPTION
Having a lot of large dependencies makes vscode slow and clunky, so I felt the need to add some way of excluding dependency paths from being added to the visual studio code workspace.
This does not affect the include paths in c_cpp_properties.json which means linting and other static analysis should still work fine.
