### PR TITLE
Options to generate fewer vscode launch configs

### DIFF
--- a/mod/tools/vscode.py
+++ b/mod/tools/vscode.py
@@ -1,6 +1,6 @@
 '''VSCode helper functions'''
 import platform,subprocess, os, yaml, json, inspect, tempfile, glob, shutil
-from mod import util,log,verb,dep
+from mod import util, log, verb, dep, settings
 from mod.tools import cmake
 
 name = 'vscode'
@@ -240,8 +240,15 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg):
     deploy_dir = util.get_deploy_dir(fips_dir, proj_name, cfg['name'])
     build_dir = util.get_build_dir(fips_dir, proj_name, cfg['name'])
 
-    pre_launch_build_options = [('', True), (' [Skip Build]', False)]
-    stop_at_entry_options = [('', False), (' [Stop At Entry]', True)]
+    if settings.get(proj_dir, "vscode_launch_configs") == "minimal":
+        pre_launch_build_options = [('', True)]
+        stop_at_entry_options = [('', False)]
+    elif settings.get(proj_dir, "vscode_launch_configs") == "skip_build":
+        pre_launch_build_options = [('', True), (' [Skip Build]', False)]
+        stop_at_entry_options = [('', False)]
+    else:    
+        pre_launch_build_options = [('', True), (' [Skip Build]', False)]
+        stop_at_entry_options = [('', False), (' [Stop At Entry]', True)]
 
     launch = {
         'version': '0.2.0',

--- a/mod/tools/vscode.py
+++ b/mod/tools/vscode.py
@@ -240,10 +240,10 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg):
     deploy_dir = util.get_deploy_dir(fips_dir, proj_name, cfg['name'])
     build_dir = util.get_build_dir(fips_dir, proj_name, cfg['name'])
 
-    if settings.get(proj_dir, "vscode_launch_configs") == "minimal":
+    if settings.get(proj_dir, "vscode-launch-configs") == "minimal":
         pre_launch_build_options = [('', True)]
         stop_at_entry_options = [('', False)]
-    elif settings.get(proj_dir, "vscode_launch_configs") == "skip_build":
+    elif settings.get(proj_dir, "vscode-launch-configs") == "skip-build":
         pre_launch_build_options = [('', True), (' [Skip Build]', False)]
         stop_at_entry_options = [('', False)]
     else:    

--- a/verbs/set.py
+++ b/verbs/set.py
@@ -41,6 +41,11 @@ def run(fips_dir, proj_dir, args) :
                     settings.set(proj_dir, 'ccache', False)
                 else :
                     log.error("value for setting 'ccache' must be 'on' or 'off")
+        elif noun == 'vscode_launch_configs' :
+            if len(args) > 1 and args[1] in ['all', 'minimal', 'skip_build']:
+                settings.set(proj_dir, noun, args[1])
+            else:
+                log.error("expected one of 'all', 'minimal' or 'skip_build'")        
         else :
             settings.set(proj_dir, noun, args[1])
     else :
@@ -53,8 +58,10 @@ def help() :
             "fips set config [config-name]\n"
             "fips set target [target-name]\n" 
             "fips set jobs [num-build-jobs]\n"
-            "fips set ccache [on|off]\n"+ log.DEF +
+            "fips set ccache [on|off]\n"
+            "fips set vscode-launch-configs [all|minimal|skip-build]\n" + log.DEF +
             "    config: set active build config\n"
             "    target: set active run target\n"
             "    jobs:   set number of parallel build jobs\n"
-            "    ccache: enable/disable using ccache")
+            "    ccache: enable/disable using ccache\n"
+            "    vscode-launch-configs: set vscode launch configs to generate")

--- a/verbs/set.py
+++ b/verbs/set.py
@@ -41,11 +41,11 @@ def run(fips_dir, proj_dir, args) :
                     settings.set(proj_dir, 'ccache', False)
                 else :
                     log.error("value for setting 'ccache' must be 'on' or 'off")
-        elif noun == 'vscode_launch_configs' :
-            if len(args) > 1 and args[1] in ['all', 'minimal', 'skip_build']:
+        elif noun == 'vscode-launch-configs' :
+            if len(args) > 1 and args[1] in ['all', 'minimal', 'skip-build']:
                 settings.set(proj_dir, noun, args[1])
             else:
-                log.error("expected one of 'all', 'minimal' or 'skip_build'")        
+                log.error("expected one of 'all', 'minimal' or 'skip-build'")
         else :
             settings.set(proj_dir, noun, args[1])
     else :


### PR DESCRIPTION
Adds an additional `fips set` option so fips generates fewer launch configs on `fips gen` when using vscode configurations. 

Can be set via `fips set vscode-launch-configs [all|minimal|skip_build]`

`minimal`: Only generates one launch config per executable which builds + runs.
`skip_build`: Generates the previous configs plus one that skips builds.
`all`: Keeps the current behaviour and the default still.

My python skills are non-existant so please let me know if there are things to clean up, happy to do so!