### PR TITLE
fix obj-c compile errors on cmake >= 3.20

### DIFF
--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -240,7 +240,7 @@ macro(fips_add_file new_file)
             # mark .m as .c file for older cmake versions (bug is fixed in cmake 3.1+)
             # breaks in CMake 3.20+
             # see: https://cmake.org/cmake/help/latest/policy/CMP0119.html#policy:CMP0119
-            if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+            if (${CMAKE_VERSION} VERSION_LESS "3.1.0")
                 if ("${f_ext}" STREQUAL ".m")
                     set_source_files_properties(${cur_file} PROPERTIES LANGUAGE C)
                 endif()

--- a/cmake/fips_private.cmake
+++ b/cmake/fips_private.cmake
@@ -238,8 +238,12 @@ macro(fips_add_file new_file)
 
         if (FIPS_OSX)
             # mark .m as .c file for older cmake versions (bug is fixed in cmake 3.1+)
-            if ("${f_ext}" STREQUAL ".m")
-                set_source_files_properties(${cur_file} PROPERTIES LANGUAGE C)
+            # breaks in CMake 3.20+
+            # see: https://cmake.org/cmake/help/latest/policy/CMP0119.html#policy:CMP0119
+            if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
+                if ("${f_ext}" STREQUAL ".m")
+                    set_source_files_properties(${cur_file} PROPERTIES LANGUAGE C)
+                endif()
             endif()
 
             # handle plist files special


### PR DESCRIPTION
There was a change in CMake behaviour in 3.20, see: https://cmake.org/cmake/help/latest/policy/CMP0119.html#policy:CMP0119

Your old fix will now force .m files to be compiled as C (instead of with the C compiler), which fails. I added a check based on your comment but I have not tested this on all CMake versions. I know it works on 3.20 with my changes. 

To test the new behaviour you need have CMake >= 3.20 installed and also to define:
`cmake_minimum_required(VERSION 3.20)
`
