### PR TITLE
Add "vscode-debug-type" setting to support "lldb" (for CodeLLDB extension)

### DIFF
--- a/mod/settings.py
+++ b/mod/settings.py
@@ -36,7 +36,8 @@ human_help = {
     'ccache':   'enable/disable using ccache',
     'local':    'place build files in project directory (useful for CI/CD)',
     'iosteam':  'Apple team id for iOS development',
-    'vscode-launch-configs': 'set vscode debugger launch configs to generate'
+    'vscode-launch-configs': 'set vscode debugger launch configs to generate',
+    'vscode-debug-type': 'set vscode debugger type: default(cppdbg) or lldb for CodeLLDB extension',
 }
 
 #-------------------------------------------------------------------------------

--- a/mod/settings.py
+++ b/mod/settings.py
@@ -15,6 +15,7 @@ default_settings = {
     'local':    False,
     'iosteam':  None,
     'vscode-launch-configs': 'all',
+    'vscode-debug-type': 'cppdbg',
 }
 
 value_help = {
@@ -24,7 +25,8 @@ value_help = {
     'ccache':  'on|off',
     'local':   'on|off',
     'iosteam': 'apple-team-id',
-    'vscode-launch-configs': 'all|minimal|skip-build'
+    'vscode-launch-configs': 'all|minimal|skip-build',
+    'vscode-debug-type': 'cppdbg|lldb',
 }
 
 human_help = {

--- a/mod/settings.py
+++ b/mod/settings.py
@@ -26,7 +26,7 @@ value_help = {
     'local':   'on|off',
     'iosteam': 'apple-team-id',
     'vscode-launch-configs': 'all|minimal|skip-build',
-    'vscode-debug-type': 'cppdbg|lldb',
+    'vscode-debug-type': 'default|lldb',
 }
 
 human_help = {
@@ -37,7 +37,7 @@ human_help = {
     'local':    'place build files in project directory (useful for CI/CD)',
     'iosteam':  'Apple team id for iOS development',
     'vscode-launch-configs': 'set vscode debugger launch configs to generate',
-    'vscode-debug-type': 'set vscode debugger type: default(cppdbg) or lldb for CodeLLDB extension',
+    'vscode-debug-type': 'set vscode debugger type (lldb for CodeLLDB extension)',
 }
 
 #-------------------------------------------------------------------------------

--- a/mod/tools/vscode.py
+++ b/mod/tools/vscode.py
@@ -283,7 +283,7 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg, proj_settings):
                 elif util.get_host_platform() == 'linux':
                     c = {
                         'name': tgt + pre_launch_build[0] + stop_at_entry[0],
-                        'type': 'cppdbg',
+                        'type': proj_settings['vscode-debug-type'],
                         'request': 'launch',
                         'program': path,
                         'args': [],
@@ -295,7 +295,7 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg, proj_settings):
                 else:
                     c = {
                         'name': tgt + pre_launch_build[0] + stop_at_entry[0],
-                        'type': 'cppdbg',
+                        'type': proj_settings['vscode-debug-type'],
                         'request': 'launch',
                         'program': path,
                         'args': [],

--- a/mod/tools/vscode.py
+++ b/mod/tools/vscode.py
@@ -271,7 +271,7 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg, proj_settings):
                 if util.get_host_platform() == 'win':
                     c = {
                         'name': tgt + pre_launch_build[0] + stop_at_entry[0],
-                        'type': 'cppvsdbg',
+                        'type': 'cppvsdbg' if proj_settings['vscode-debug-type'] == 'default' else proj_settings['vscode-debug-type'],
                         'request': 'launch',
                         'program': path,
                         'args': [],
@@ -283,7 +283,7 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg, proj_settings):
                 elif util.get_host_platform() == 'linux':
                     c = {
                         'name': tgt + pre_launch_build[0] + stop_at_entry[0],
-                        'type': proj_settings['vscode-debug-type'],
+                        'type': 'cppdbg' if proj_settings['vscode-debug-type'] == 'default' else proj_settings['vscode-debug-type'],
                         'request': 'launch',
                         'program': path,
                         'args': [],
@@ -295,7 +295,7 @@ def write_launch_json(fips_dir, proj_dir, vscode_dir, cfg, proj_settings):
                 else:
                     c = {
                         'name': tgt + pre_launch_build[0] + stop_at_entry[0],
-                        'type': proj_settings['vscode-debug-type'],
+                        'type': 'cppdbg' if proj_settings['vscode-debug-type'] == 'default' else proj_settings['vscode-debug-type'],
                         'request': 'launch',
                         'program': path,
                         'args': [],


### PR DESCRIPTION
[CodeLLDB](https://github.com/vadimcn/vscode-lldb) works very well in M1 macs, it'll be nice to have option to add support instead of hand replace `cppdbg` with `lldb` ;)