### PR TITLE
build clean option, make clean help added

### DIFF
--- a/verbs/build.py
+++ b/verbs/build.py
@@ -21,14 +21,22 @@ def run(fips_dir, proj_dir, args) :
         cfg_name = args[0]
     if not cfg_name :
         cfg_name = settings.get(proj_dir, 'config')
-    project.build(fips_dir, proj_dir, cfg_name, None, build_tool_args)
+    if cfg_name == 'clean' :
+        if len(args) > 1:
+            cfg_name = args[1]
+        else :
+            cfg_name = settings.get(proj_dir, 'config')
+        project.make_clean(fips_dir, proj_dir, cfg_name)
+    else :
+        project.build(fips_dir, proj_dir, cfg_name, None, build_tool_args)
 
 #-------------------------------------------------------------------------------
 def help() :
     """print build help"""
-    log.info(log.YELLOW + 
-            "fips build [-- build tool args]\n" 
-            "fips build [config] [-- build tool args]\n" + log.DEF + 
+    log.info(log.YELLOW +
+            "fips build clean [config]\n"
+            "fips build [-- build tool args]\n"
+            "fips build [config] [-- build tool args]\n" + log.DEF +
             "    perform a build for current or named config\n" +
             "    any args following a -- will be forwarded to the invoked build tool")
-    
+

--- a/verbs/make.py
+++ b/verbs/make.py
@@ -35,11 +35,11 @@ def run(fips_dir, proj_dir, args) :
 #-------------------------------------------------------------------------------
 def help() :
     """print 'make' help"""
-    log.info(log.YELLOW + 
-            "fips make [-- build tool args]\n" 
+    log.info(log.YELLOW +
+            "fips make clean\n"
+            "fips make [-- build tool args]\n"
             "fips make [target] [-- build tool args]\n"
             "fips make [target] [config] [-- build tool args]\n" + log.DEF +
             "    build a single target in current or named config\n" +
             "    any args following a -- will be forwarded to the invoked build tool")
-    
 


### PR DESCRIPTION
Added a 'clean' option to 'fips build', there is one under 'fips make clean' but it wasn't in the help description. So, added that too. :)

Let me know what you think, I'm not 100% sure on syntax. Is there a way to grab all the configs currently generated? With this setup you can do 'fips build clean win64-vs*' and it will clean all VS builds. But you get an error if one doesn't exists. 