### PR TITLE
mute xcode library errors

### DIFF
--- a/mod/tools/xcodebuild.py
+++ b/mod/tools/xcodebuild.py
@@ -9,11 +9,11 @@ not_found = 'please install Xcode and Xcode cmd line tools'
 #------------------------------------------------------------------------------
 def check_exists(fips_dir) :
     """test if xcodebuild is in the path
-    
+
     :returns:   True if xcodebuild is in the path
     """
     try :
-        subprocess.check_output(['xcodebuild', '-version'])
+        subprocess.check_output(['xcodebuild', '-version'], stderr=subprocess.DEVNULL)
         return True
     except (OSError, subprocess.CalledProcessError) :
         return False
@@ -40,7 +40,7 @@ def run_build(fips_dir, target, build_type, build_dir, num_jobs=1, args=None) :
         args_str = ' '.join(args)
     cmdLine = 'xcodebuild -jobs {} -configuration {} -target {} {}'.format(num_jobs, build_type, target, args_str)
     print(cmdLine)
-    res = subprocess.call(cmdLine, cwd=build_dir, shell=True)
+    res = subprocess.call(cmdLine, cwd=build_dir, shell=True, stderr=subprocess.DEVNULL)
     return res == 0
 
 #------------------------------------------------------------------------------
@@ -51,9 +51,9 @@ def run_clean(fips_dir, build_dir) :
     :returns:           True if xcodebuild returns successful
     """
     try :
-        res = subprocess.call('xcodebuild clean', cwd=build_dir, shell=True)
+        res = subprocess.call('xcodebuild clean', cwd=build_dir, shell=True, stderr=subprocess.DEVNULL)
         return res == 0
     except (OSError, subprocess.CalledProcessError) :
         return False
 
-    
+

--- a/mod/tools/xcrun.py
+++ b/mod/tools/xcrun.py
@@ -9,11 +9,11 @@ not_found = 'please install Xcode and Xcode cmd line tools'
 #------------------------------------------------------------------------------
 def check_exists(fips_dir) :
     """test if xcrun is in the path
-    
+
     :returns:   True if xcrun is in the path
     """
     try:
-        subprocess.check_output(['xcrun', '-version'])
+        subprocess.check_output(['xcrun', '-version'], stderr=subprocess.DEVNULL)
         return True
     except (OSError, subprocess.CalledProcessError):
         return False
@@ -21,13 +21,15 @@ def check_exists(fips_dir) :
 #------------------------------------------------------------------------------
 def get_macos_sdk_sysroot():
     try:
-        return subprocess.check_output(['xcrun', '--sdk', 'macosx', '--show-sdk-path']).decode('utf-8').rstrip()
+        return subprocess.check_output(['xcrun', '--sdk', 'macosx', '--show-sdk-path'],
+            stderr=subprocess.DEVNULL).decode('utf-8').rstrip()
     except (OSError, subprocess.CalledProcessError):
         return None
 
 #------------------------------------------------------------------------------
 def get_ios_sdk_sysroot():
     try:
-        return subprocess.check_output(['xcrun', '--sdk', 'iphoneos', '--show-sdk-path']).decode('utf-8').rstrip()
+        return subprocess.check_output(['xcrun', '--sdk', 'iphoneos', '--show-sdk-path'],
+            stderr=subprocess.DEVNULL).decode('utf-8').rstrip()
     except (OSError, subprocess.CalledProcessError):
         return None


### PR DESCRIPTION
You might have seen this or not, but if Xcode cmd libs doesn't match with macOS versions (on M1 machines), you get spammed by errors each time you run xcodebuild or xcrun. These changes redirect stderr to /dev/null, and hides these error messages. It's basically the same as writing 'fips build 2> /dev/null' on the cmd line.

This syntax requires python 3.3, but I think you've switched to python3 now anyways?

I haven't tested this a lot, hopefully this doesn't break any edge cases.