### PR TITLE
Add config file for MSVC 2022, and support for MSVC ClangCL

### DIFF
--- a/cmake/fips.cmake
+++ b/cmake/fips.cmake
@@ -130,11 +130,15 @@ macro(fips_setup)
         set(FIPS_HOST_LINUX 1)
     endif()
 
-    # detect compiler
+    # detect compiler and frontend
     message("CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
     if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         set(FIPS_CLANG 1)
         message("Detected C++ Compiler: Clang (FIPS_CLANG)")
+        if ("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" MATCHES "MSVC")
+            message("Detected frontend: MSVC (FIPS_CLANGCL)")
+            set(FIPS_CLANGCL 1)
+        endif ()
     elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
         set(FIPS_GCC 1)
         message("Detected C++ Compiler: GCC (FIPS_GCC)")

--- a/configs/win64-vs2022-clangcl-debug.yml
+++ b/configs/win64-vs2022-clangcl-debug.yml
@@ -1,0 +1,7 @@
+---
+platform: win64
+generator: Visual Studio 17 2022
+generator-platform: x64
+generator-toolset: ClangCL
+build_tool: cmake
+build_type: Debug

--- a/configs/win64-vs2022-clangcl-release.yml
+++ b/configs/win64-vs2022-clangcl-release.yml
@@ -1,0 +1,7 @@
+---
+platform: win64
+generator: Visual Studio 17 2022
+generator-platform: x64
+generator-toolset: ClangCL
+build_tool: cmake
+build_type: Release

--- a/configs/win64-vs2022-debug.yml
+++ b/configs/win64-vs2022-debug.yml
@@ -1,0 +1,6 @@
+---
+platform: win64
+generator: Visual Studio 17 2022
+generator-platform: x64
+build_tool: cmake
+build_type: Debug

--- a/configs/win64-vs2022-release.yml
+++ b/configs/win64-vs2022-release.yml
@@ -1,0 +1,6 @@
+---
+platform: win64
+generator: Visual Studio 17 2022
+generator-platform: x64
+build_tool: cmake
+build_type: Release


### PR DESCRIPTION
Added configuration files for Visual Studio 2022, and support for ClangCL which ships with Visual Studio. ClangCL uses the same flags as normal MSVC cl. My changes will detect MSVC frontend and sets FIPS_MSVC flag.

Any cmake script that checks for MSVC should work, but some that checks for FIPS_CLANG without checking for !FIPS_MSVC might setup incorrect flags for ClangCL. Normal Clang should work with these changes.

ClangCL accepts some of clangs flags, for instance "-Wno-unused-function". I haven't found a good overview of this yet. But it means you have to do things like this:

```
    if (FIPS_MSVC)
        # used by CL and ClangCL
        target_compile_options(${target_name} PUBLIC /GR- /GS- /std:c++20 /std:c17 /fp:fast)
    endif()
    if (FIPS_CLANG)
        if (!FIPS_MSVC)
            # clang
            target_compile_options(${target_name} PUBLIC -ffast-math -fno-rtti)
        endif()
        # used by both Clang and ClangCL
        target_compile_options(${target_name} PUBLIC -Wno-unused-function)
    endif()
```

Maybe there's another option, or maybe there should be a FIPS_CLANG_CL flag?
