### PR TITLE
Fix the issue of inability to start on Android 14

### DIFF
--- a/tools/android-create-apk.py
+++ b/tools/android-create-apk.py
@@ -116,6 +116,7 @@ with open(apk_dir + 'AndroidManifest.xml', 'w') as f:
     f.write('    <activity android:name="android.app.NativeActivity"\n');
     f.write('      android:label="{}"\n'.format(args.name))
     f.write('      android:launchMode="singleTask"\n')
+    f.write('      android:exported="true"\n')
     f.write('      android:screenOrientation="fullUser"\n')
     f.write('      android:configChanges="orientation|screenSize|keyboard|keyboardHidden">\n')
     f.write('      <meta-data android:name="android.app.lib_name" android:value="{}"/>\n'.format(args.name))


### PR DESCRIPTION
Fix the issue where setting android:exported="true" is required to start an Activity on Android 14