### PR TITLE
also writes hgignore now

### DIFF
--- a/mod/project.py
+++ b/mod/project.py
@@ -7,6 +7,9 @@ import subprocess
 from mod import log, util, config, dep, template, settings, android, emsdk, wasisdk
 from mod.tools import git, cmake, xcrun, ccmake, cmake_gui, vscode, clion, httpserver, wasmtime
 
+
+gitignore_entries = ['.fips-*', 'fips-files/build/', 'fips-files/deploy/', '*.pyc', '.vscode/', '.idea/', 'CMakeUserPresets.json']
+
 #-------------------------------------------------------------------------------
 def init(fips_dir, proj_name) :
     """initialize an existing project directory as a fips directory by
@@ -24,7 +27,6 @@ def init(fips_dir, proj_name) :
         for f in ['CMakeLists.txt', 'fips', 'fips.cmd', 'fips.yml'] :
             template.copy_template_file(fips_dir, proj_dir, f, templ_values)
         os.chmod(proj_dir + '/fips', 0o744)
-        gitignore_entries = ['.fips-*', 'fips-files/build/', 'fips-files/deploy/', '*.pyc', '.vscode/', '.idea/', 'CMakeUserPresets.json']
         template.write_git_ignore(proj_dir, gitignore_entries)
     else :
         log.error("project dir '{}' does not exist".format(proj_dir))
@@ -111,6 +113,7 @@ def gen(fips_dir, proj_dir, cfg_name) :
     dep.fetch_imports(fips_dir, proj_dir)
     util.ensure_valid_project_dir(proj_dir)
     dep.gather_and_write_imports(fips_dir, proj_dir, cfg_name)
+    template.write_git_ignore(proj_dir, gitignore_entries)
 
     # load the config(s)
     configs = config.load(fips_dir, proj_dir, cfg_name)

--- a/mod/template.py
+++ b/mod/template.py
@@ -7,40 +7,58 @@ from mod import log, util
 
 #-------------------------------------------------------------------------------
 def write_git_ignore(proj_dir, entries) :
-    """modify or create the .gitignore file with fips-specific
+    """modify or create the .gitignore or .hgignore file with fips-specific
     entries. fips entries will go into a special section marked with:
         #>fips
         #<fips
 
-    :param entries: array of fips .gitignore strings
+    :param entries: array of fips .gitignore or .hgignore strings
     """
-    path = proj_dir + '/.gitignore'
-    out_lines = []
-    if os.path.isfile(path) :
-        # .gitignore already exists, read into lines array,
-        # but drop everything between #>fips and #<fips
-        with open(path, 'r') as f :
-            in_lines = f.readlines()
-        copy_line = True
-        for l in in_lines :
-            if '#>fips' in l :
-                copy_line = False
-            if copy_line :
-                out_lines.append(l)
-            if '#<fips' in l :
-                copy_line = True
-    
-    # append the fips .gitignore entries
-    out_lines.append('#>fips\n')
-    out_lines.append('# this area is managed by fips, do not edit\n')
-    out_lines.extend('\n'.join(entries) + '\n')
-    out_lines.append('#<fips\n')
 
-    # write back .gitignore file
-    with open(path, 'w') as f :
-        f.writelines(out_lines)
+    for flavour in ["git", "hg"]:
+        if "hg" == flavour:
+            if not os.path.isdir(proj_dir + "/.hg"):
+                # hg only uses an ignore file in the root
+                # ... if you think we should search for that;
+                #       https://github.com/g-pechorin/fips/issues
+                return
 
-    log.info("wrote '{}'".format(path))
+        path = proj_dir + f"/.{flavour}ignore"
+        out_lines = []
+        if os.path.isfile(path):
+            # .gitignore already exists, read into lines array,
+            # but drop everything between #>fips and #<fips
+            with open(path, "r") as f:
+                in_lines = f.readlines()
+            copy_line = True
+            for line in in_lines:
+                if "#>fips" in line:
+                    copy_line = False
+                if copy_line:
+                    out_lines.append(line)
+                if "#<fips" in line:
+                    copy_line = True
+
+        # append the fips .gitignore entries
+        out_lines.append("#>fips\n")
+        out_lines.append("# this area is managed by fips, do not edit\n")
+
+        if "hg" == flavour:
+            # always switch to glob (it's safe because we're at the end!)
+            out_lines.append("syntax: glob\n")
+            out_lines.append(".gitignore\n")
+        else:
+            out_lines.append(".hgignore\n")
+
+        out_lines.extend("\n".join(entries) + "\n")
+        out_lines.append("#<fips\n")
+
+        # write back .gitignore file
+        with open(path, "w") as f:
+            f.writelines(out_lines)
+
+        log.info("wrote '{}'".format(path))
+
     
 #-------------------------------------------------------------------------------
 def copy_template_file(fips_dir, proj_dir, filename, values, silent=False) :
@@ -78,10 +96,3 @@ def copy_template_file(fips_dir, proj_dir, filename, values, silent=False) :
     if not silent :
         log.info("wrote '{}'".format(dst_path))
     return True
-
-
-
-
-
-
-


### PR DESCRIPTION
i'm still using hg. for vcs.
fips can be (trivially?) changed  to support myself (and others) in this.
this PR;
- writes the `# fips >` section to `.hgignore` if `.hg/` exists
- regenerates the ignore files on `fips gen`